### PR TITLE
cmogstored v1.6.0

### DIFF
--- a/Dockerfile.centos5
+++ b/Dockerfile.centos5
@@ -3,8 +3,8 @@ MAINTAINER hiroyan@gmail.com
 
 RUN yum -y install gcc wget tar make
 
-RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.5.0.tar.gz | tar xz -C /usr/local/src
+RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.6.0.tar.gz | tar xz -C /usr/local/src
 
-WORKDIR /usr/local/src/cmogstored-1.5.0
+WORKDIR /usr/local/src/cmogstored-1.6.0
 RUN ./configure
 RUN make

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -3,9 +3,9 @@ MAINTAINER hiroyan@gmail.com
 
 RUN yum -y install gcc wget tar make
 
-RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.5.0.tar.gz | tar xz -C /usr/local/src
+RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.6.0.tar.gz | tar xz -C /usr/local/src
 
-WORKDIR /usr/local/src/cmogstored-1.5.0
+WORKDIR /usr/local/src/cmogstored-1.6.0
 RUN ./configure
 RUN make
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -3,8 +3,8 @@ MAINTAINER hiroyan@gmail.com
 
 RUN yum -y install gcc wget tar make
 
-RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.5.0.tar.gz | tar xz -C /usr/local/src
+RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.6.0.tar.gz | tar xz -C /usr/local/src
 
-WORKDIR /usr/local/src/cmogstored-1.5.0
+WORKDIR /usr/local/src/cmogstored-1.6.0
 RUN ./configure
 RUN make

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -4,7 +4,7 @@ MAINTAINER hfm.garden@gmail.com
 RUN apt update && apt dist-upgrade -qy
 RUN apt-get install -y build-essential wget
 
-RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.5.0.tar.gz | tar xzC /usr/local/src
+RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.6.0.tar.gz | tar xzC /usr/local/src
 
-WORKDIR /usr/local/src/cmogstored-1.5.0
+WORKDIR /usr/local/src/cmogstored-1.6.0
 RUN ./configure && make

--- a/Dockerfile.ubuntu1504
+++ b/Dockerfile.ubuntu1504
@@ -4,7 +4,7 @@ MAINTAINER hfm.garden@gmail.com
 RUN apt update && apt dist-upgrade -qy
 RUN apt-get install -y build-essential wget
 
-RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.5.0.tar.gz | tar xzC /usr/local/src
+RUN wget -O- http://bogomips.org/cmogstored/files/cmogstored-1.6.0.tar.gz | tar xzC /usr/local/src
 
-WORKDIR /usr/local/src/cmogstored-1.5.0
+WORKDIR /usr/local/src/cmogstored-1.6.0
 RUN ./configure && make

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,34 @@
 centos5:
   dockerfile: Dockerfile.centos5
   build: .
-  command: cp -a /usr/local/src/cmogstored-1.5.0/cmogstored /tmp/cmogstored.centos5
+  command: cp -a /usr/local/src/cmogstored-1.6.0/cmogstored /tmp/cmogstored.centos5
   volumes:
     - .:/tmp:rw
 
 centos6:
   dockerfile: Dockerfile.centos6
   build: .
-  command: cp -a /usr/local/src/cmogstored-1.5.0/cmogstored /tmp/cmogstored.centos6
+  command: cp -a /usr/local/src/cmogstored-1.6.0/cmogstored /tmp/cmogstored.centos6
   volumes:
     - .:/tmp:rw
 
 centos7:
   dockerfile: Dockerfile.centos7
   build: .
-  command: cp -a /usr/local/src/cmogstored-1.5.0/cmogstored /tmp/cmogstored.centos7
+  command: cp -a /usr/local/src/cmogstored-1.6.0/cmogstored /tmp/cmogstored.centos7
   volumes:
     - .:/tmp:rw
 
 ubuntu1404:
   dockerfile: Dockerfile.ubuntu1404
   build: .
-  command: cp -a /usr/local/src/cmogstored-1.5.0/cmogstored /tmp/cmogstored.ubuntu1404
+  command: cp -a /usr/local/src/cmogstored-1.6.0/cmogstored /tmp/cmogstored.ubuntu1404
   volumes:
     - .:/tmp:rw
 
 ubuntu1504:
   dockerfile: Dockerfile.ubuntu1504
   build: .
-  command: cp -a /usr/local/src/cmogstored-1.5.0/cmogstored /tmp/cmogstored.ubuntu1504
+  command: cp -a /usr/local/src/cmogstored-1.6.0/cmogstored /tmp/cmogstored.ubuntu1504
   volumes:
     - .:/tmp:rw


### PR DESCRIPTION
@hiboma Hi hiroyan-san :hand: cmogstored v1.6.0 has been released.

```
https://bogomips.org/cmogstored/NEWS
1.6.0 / 2016-08-31 03:14 UTC
----------------------------

  There are minor robustness fixes on handling errors when
  allocating memory or spawn failures on otherwise-hosed systems.
  These bugfixes will not affect real users unless the system
  is already hosed or in badly overtaxed, so there's no real
  need to upgrade.

  There are minor portability improvements and I now test under
  FreeBSD 10.x.

  The iostat test cases are relaxed a bit to account for
  virtualized devices (as iostat is less useful with modern

  17 changes since 1.5.0 (Nov 2015):
        Rakefile: add missing <div> for Atom feed
        test/pwrite-wrap: remove unused variable and comment
        test/pwrite_wrap: squelch unnecessary output
        test/pwrite_wrap: reduce space overhead required
        update copyrights for 2016
        build-aux/txt2pre: drop CGI.pm requirement
        stdin is always redirected to /dev/null
        minor vfork/fork safety fixes
        process: try to handle OOM gracefully
        http_put: gracefully handle path allocation errors
        iostat_process: declare environ extern
        test/mgmt: relax checks for iostat mapping
        gnulib copyright update for 2016
        upgrade: avoid syslog call if execve fails
        rely on gnulib for environ portability
        INSTALL: update latest Debian stable version to 8.x
        README: stop mentioning cgit
```